### PR TITLE
Add attributes reorder and entities rename functionality

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -22,6 +22,7 @@ pub struct Attribute {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Entity {
     pub id: usize,
+    pub name: String,
     pub attributes: HashMap<String, Attribute>,  // Stores attributes with name and value type
     pub attribute_order: Vec<String>,
 }
@@ -50,6 +51,7 @@ impl Entity {
     pub fn new(id: usize) -> Self {
         Entity {
             id,
+            name: String::new(),
             attributes: HashMap::new(),
             attribute_order: Vec::new(),
         }
@@ -186,6 +188,7 @@ impl EntityManager {
     pub fn copy_entity(&mut self, existing_entity: &Entity) -> Entity {
         let new_entity = Entity {
             id: self.next_id,
+            name: existing_entity.name.clone(),
             attributes: existing_entity.attributes.clone(),  // Copy all attributes
             attribute_order: existing_entity.attribute_order.clone(),
         };
@@ -321,6 +324,12 @@ impl EntityManager {
     pub fn update_entity_attribute_order(&mut self, entity_id: usize, new_order: Vec<String>) {
         if let Some(entity) = self.entities.get_mut(&entity_id) {
             entity.attribute_order = new_order;
+        }
+    }
+
+    pub fn update_entity_name(&mut self, entity_id: usize, name: String) {
+        if let Some(entity) = self.entities.get_mut(&entity_id) {
+            entity.name = name;
         }
     }
 }

--- a/src/engine_gui.rs
+++ b/src/engine_gui.rs
@@ -41,21 +41,14 @@ pub struct EngineGui {
 
 impl Default for EngineGui {
     fn default() -> Self {
-
-        let project_path = "/Users/Frank/Documents/school_work/Rust-2D-Game-Engine/test_project/";
-        let project_name = "test_project";
-
         Self {
             ecs: EntityManager::new(),
             render_engine: RenderEngine::new(),
             show_new_project_popup: false,
             show_open_project_popup: false,
-            // load_project: false,
-            // project_name: String::new(),
-            // project_path: String::new(),
-            load_project: true,
-            project_name: project_name.to_string(),
-            project_path: project_path.to_string(),
+            load_project: false,
+            project_name: String::new(),
+            project_path: String::new(),
             terminal_output: String::new(),
             // entities panel
             highlighted_entity: None,


### PR DESCRIPTION
- Entity attributes can now be reordered
    - Add a popup window for reordering attributes
    - Add a new `attribute_order` field to `Entity`
- Entity name can now be renamed
    - Add a popup window for renaming entities
    - Add a new `name` field in `Entity`