### PR TITLE
Highlight code in editor, synchronize dev and play views, and add persistent state data for Lua scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,12 +589,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.7.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1288,6 +1303,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3c1f5cd8dfe2ade470a218696c66cf556fcfd701e7830fa2e9f4428292a2a1"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "log",
+ "mime_guess2",
+ "syntect",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1362,27 @@ name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1444,6 +1494,16 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
 ]
 
 [[package]]
@@ -2334,6 +2394,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess2"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a3333bb1609500601edc766a39b4c1772874a4ce26022f4d866854dc020c41"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.6.0",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
@@ -2930,28 +3006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "orbclient"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,7 +3420,7 @@ checksum = "643116992c25c96a07e1aae7d59fba207f01979dc9a107c42bcd4c4b83ef78b2"
 dependencies = [
  "approx",
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.7.0",
  "bitflags 2.6.0",
  "crossbeam",
  "downcast-rs",
@@ -3585,6 +3639,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "egui-winit",
+ "egui_extras",
  "futures",
  "image",
  "indexmap",
@@ -3599,7 +3654,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syntect",
  "uuid",
  "wgpu",
  "winit",
@@ -3987,10 +4041,10 @@ checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
+ "fancy-regex",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "plist",
  "regex-syntax",
  "serde",
@@ -4252,6 +4306,12 @@ dependencies = [
  "tempfile",
  "winapi",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -4611,7 +4671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.7.0",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "document-features",
@@ -4638,7 +4698,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.6.0",
  "bitflags 2.6.0",
  "block",
  "cfg_aliases 0.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 egui = "0.29.1"
-syntect = "5.0"
+egui_extras = { version = "0.29.1", features = ["syntect"] }
 eframe = "0.29.1" # renderer of the engine UI
 serde = { version = "1.0.210", features = ["derive"] }
 uuid = { version = "1.7.0", features = ["v4", "serde"] }

--- a/demo/flappy_bird/assets/scripts/pipe_spawner.lua
+++ b/demo/flappy_bird/assets/scripts/pipe_spawner.lua
@@ -76,15 +76,31 @@ function cleanup_pipes(scene_id)
     end
 end
 
+print(accumulated_time);
+
 -- main entry point for Rust to call
 function update(scene_id, entity_id)
     --print("Updating entity " .. entity_id .. " in scene " .. scene_id)
 
-    if math.random() < 0.05 then
+    local script_key = "pipe_spawner"
+
+    if script_state["state"][script_key] == nil then
+        script_state["state"][script_key] = { last_trigger_time = 0.0 }
+    end
+    print("last_trigger_time:" .. script_state["state"][script_key].last_trigger_time)
+
+    local state = script_state["state"][script_key]
+
+    -- Time threshold for triggering (in seconds)
+    local time_interval = 2.0
+
+    if accumulated_time - state.last_trigger_time >= time_interval then
+        state.last_trigger_time = accumulated_time
+
         -- Generate random x and y positions
         local random_x = math.random(300, 400)
-        local random_top_y = math.random(-200, -50)
-        local random_bottom_y = math.random(50, 150)
+        local random_top_y = math.random(-100, -50) -- above top
+        local random_bottom_y = math.random(100, 150) -- at least below top pipe, otherwise they hit each other and stop outside of the scene
 
         -- Create top pipe
         local top_pipe_id = create_pipe(

--- a/src/engine_gui.rs
+++ b/src/engine_gui.rs
@@ -15,11 +15,6 @@ use eframe::egui;
 use std::fs;
 use std::path::PathBuf;
 
-use egui::text::LayoutJob;
-use syntect::highlighting::{ThemeSet, Style};
-use syntect::parsing::SyntaxSet;
-use syntect::easy::HighlightLines;
-
 struct ConsoleMessage {
     text: String,
     timestamp: chrono::DateTime<chrono::Local>,
@@ -306,41 +301,17 @@ impl EngineGui {
                                 egui::Color32::from_gray(40),
                             );
 
-                            fn highlight_lua_code(code: &str, dark_mode: bool) -> LayoutJob {
-                                let mut job = LayoutJob::default();
-
-                                let syntax_set = SyntaxSet::load_defaults_nonewlines();
-                                let syntax = syntax_set.find_syntax_by_extension("lua").unwrap();
-                                let theme_set = ThemeSet::load_defaults();
-                                // base16-ocean.dark, InspiredGitHub, Solarized (dark), Solarized (light)
-                                let theme_name = if dark_mode {
-                                    "base16-ocean.dark"
-                                } else {
-                                    "InspiredGitHub"
-                                };
-                                let theme = &theme_set.themes[theme_name];
-                                let mut highlighter = HighlightLines::new(syntax, theme);
-
-                                for line in code.lines() {
-                                    let ranges: Vec<(Style, &str)> = highlighter.highlight_line(line, &syntax_set).unwrap();
-                                    for (style, text) in ranges {
-                                        let color = egui::Color32::from_rgb(style.foreground.r, style.foreground.g, style.foreground.b);
-                                        let format = egui::TextFormat {
-                                            font_id: egui::FontId::monospace(12.0),
-                                            color,
-                                            ..Default::default()
-                                        };
-                                        job.append(text, 0.0, format);
-                                    }
-                                    job.append("\n", 0.0, egui::TextFormat::default());
-                                }
-                                job
-                            }
-
-                            let dark_mode = self.gui_state.dark_mode;
+                            let theme =
+                                egui_extras::syntax_highlighting::CodeTheme::from_memory(ui.ctx(), ui.style());
 
                             let mut layouter = |ui: &egui::Ui, string: &str, wrap_width: f32| {
-                                let mut layout_job = highlight_lua_code(string, dark_mode);
+                                let mut layout_job = egui_extras::syntax_highlighting::highlight(
+                                    ui.ctx(),
+                                    ui.style(),
+                                    &theme,
+                                    string,
+                                    "lua",
+                                );
                                 layout_job.wrap.max_width = wrap_width;
                                 ui.fonts(|f| f.layout_job(layout_job))
                             };

--- a/src/game_runtime.rs
+++ b/src/game_runtime.rs
@@ -341,4 +341,9 @@ impl GameRuntime {
     pub fn set_game(&mut self, game: Box<dyn Game>) {
         self.game = Some(game);
     }
+
+    pub fn set_camera_state(&mut self, position: (f32, f32), zoom: f32) {
+        self.render_engine.camera.position = position;
+        self.render_engine.camera.zoom = zoom;
+    }
 }

--- a/src/game_runtime.rs
+++ b/src/game_runtime.rs
@@ -186,6 +186,7 @@ impl GameRuntime {
             }
 
             // Run script
+            self.lua_scripting.update_global_time(1.0/self.target_fps as f32).expect("Failed to update global time");
             match self.lua_scripting.load_scene_manager(&self.scene_manager) {
                 Ok(_) => println!("SceneManager loaded into Lua successfully."),
                 Err(err) => eprintln!("Error loading SceneManager into Lua: {}", err),
@@ -193,6 +194,7 @@ impl GameRuntime {
             if let Some(active_scene_id) = self.scene_manager.active_scene {
                 self.lua_scripting.initialize_bindings_physics_engine(&mut self.physics_engine, &mut self.scene_manager).unwrap();
                 self.lua_scripting.initialize_bindings_ecs(&mut self.scene_manager).unwrap();
+                self.lua_scripting.initializing_global_variables();
 
                 match self.lua_scripting.run_scripts_for_scene(&mut self.scene_manager, active_scene_id) {
                     Ok(()) => {

--- a/src/physics_engine.rs
+++ b/src/physics_engine.rs
@@ -61,8 +61,8 @@ impl PhysicsEngine {
 
             // Physics runs at 60Hz (60 updates per second)
             integration_parameters: IntegrationParameters {
-                dt: 1.0 / 120.0,
-                min_ccd_dt: 1.0 / 120.0 / 100.0,
+                dt: 1.0 / 60.0,
+                min_ccd_dt: 1.0 / 60.0 / 100.0,
                 contact_damping_ratio: 0.0,
                 contact_natural_frequency: 30.0,
                 joint_natural_frequency: 30.0,
@@ -82,7 +82,7 @@ impl PhysicsEngine {
             query_pipeline: QueryPipeline::new(),
             entity_to_body: HashMap::new(),
             entity_to_collider: HashMap::new(),
-            time_step: 1.0 / 120.0,  // Default 60Hz physics
+            time_step: 1.0 / 60.0,  // Default 60Hz physics
             entity_position_attrs: HashMap::new(),
         }
     }


### PR DESCRIPTION
- Replaced the use of the `syntect` crate with the `egui_extras` package for Lua syntax highlighting in the code editor. `egui_extras` internally integrates `syntect`, simplifying the codebase and improving compatibility with `egui`.
- Aligned the development view with the playing view to improve debugging by allowing entities outside of scenes to be visible.
- Implemented time tracking and persistent state data for Lua scripts, enabling consistent state management across script executions.
