### PR TITLE
Refractor logger, add popup to build project, log msg in both terminal and debug panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "lofty",
  "mlua 0.10.2",
  "mockall",
+ "once_cell",
  "rapier2d",
  "rayon",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,12 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -532,7 +538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
 dependencies = [
  "anyhow",
- "arrayvec",
+ "arrayvec 0.7.6",
  "log",
  "nom",
  "num-rational",
@@ -545,7 +551,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -2048,7 +2054,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4419f022e55cc63d5bbd6b44b71e1d226b9c9480a47824c706e9d54e5c40c5eb"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -2517,7 +2523,7 @@ version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "bit-set 0.6.0",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
@@ -3087,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02fcab5e08cd7768c17e5d372877246c36882fde540598664ae20918d8c155"
 dependencies = [
  "approx",
- "arrayvec",
+ "arrayvec 0.7.6",
  "bitflags 2.6.0",
  "downcast-rs",
  "either",
@@ -3419,7 +3425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643116992c25c96a07e1aae7d59fba207f01979dc9a107c42bcd4c4b83ef78b2"
 dependencies = [
  "approx",
- "arrayvec",
+ "arrayvec 0.7.6",
  "bit-vec 0.7.0",
  "bitflags 2.6.0",
  "crossbeam",
@@ -3443,7 +3449,7 @@ checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.6",
  "av1-grain",
  "bitstream-io",
  "built",
@@ -3655,6 +3661,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strip-ansi-escapes",
  "uuid",
  "wgpu",
  "winit",
@@ -3964,6 +3971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,7 +4009,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "bitflags 1.3.2",
  "bytemuck",
  "lazy_static",
@@ -4172,7 +4188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.6",
  "bytemuck",
  "cfg-if",
  "log",
@@ -4372,6 +4388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,6 +4425,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"
@@ -4646,7 +4689,7 @@ version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "cfg_aliases 0.1.1",
  "document-features",
  "js-sys",
@@ -4671,7 +4714,7 @@ version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "bit-vec 0.7.0",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
@@ -4697,7 +4740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
 dependencies = [
  "android_system_properties",
- "arrayvec",
+ "arrayvec 0.7.6",
  "ash",
  "bit-set 0.6.0",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rayon = "1.10.0"
 lofty = "0.15.0"
 sha2 = "0.10.8"
 once_cell = "1.20.2"
+strip-ansi-escapes = "0.1.1"
 [dev-dependencies]
 mockall = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = { version = "2.2.3", features = ["serde", "rayon"] }
 rayon = "1.10.0"
 lofty = "0.15.0"
 sha2 = "0.10.8"
+once_cell = "1.20.2"
 [dev-dependencies]
 mockall = "0.11"
 

--- a/src/gui/gui_state.rs
+++ b/src/gui/gui_state.rs
@@ -2,6 +2,7 @@ use crate::ecs::SceneManager;
 use crate::project_manager::ProjectMetadata;
 use std::path::PathBuf;
 use uuid::Uuid;
+use std::sync::{Arc, Mutex};
 
 pub enum SelectedItem {
     None,
@@ -35,6 +36,11 @@ pub struct GuiState {
 
     pub selected_item: SelectedItem,
     pub scene_panel_selected_item: ScenePanelSelectedItem,
+
+    pub build_result: Arc<Mutex<Option<Result<(), String>>>>,
+    pub is_building: Arc<Mutex<bool>>,
+    pub show_build_project_popup: bool,
+
 }
 
 impl GuiState {
@@ -56,6 +62,10 @@ impl GuiState {
 
             selected_item: SelectedItem::None,
             scene_panel_selected_item: ScenePanelSelectedItem::None,
+
+            build_result: Arc::new(Mutex::new(None)),
+            is_building: Arc::new(Mutex::new(false)),
+            show_build_project_popup: false,
         }
     }
 }

--- a/src/gui/menu_bar.rs
+++ b/src/gui/menu_bar.rs
@@ -62,6 +62,9 @@ impl MenuBar {
             ui.menu_button("Project", |ui| {
                 self.project_menu.show(ctx, ui, gui_state);
             });
+
+            // Render popup window globally
+            self.project_menu.show_active_popup(ctx, gui_state);
         });
     }
 

--- a/src/gui/menus/project_menu.rs
+++ b/src/gui/menus/project_menu.rs
@@ -1,5 +1,8 @@
 use eframe::egui;
 use crate::gui::gui_state::GuiState;
+use crate::logger::LOGGER;
+use std::sync::{Arc};
+use crate::project_manager::ProjectManager;
 
 pub struct ProjectMenu;
 
@@ -9,7 +12,93 @@ impl ProjectMenu {
     }
 
     pub fn show(&mut self, ctx: &egui::Context, ui: &mut egui::Ui, gui_state: &mut GuiState) {
-        ui.button("Build Project");
+
+        ui.add_enabled(!gui_state.project_path.as_os_str().is_empty(), egui::Button::new("Build Project")).clicked().then(|| {
+
+            let project_path = gui_state.project_path.clone();
+            let build_result = Arc::clone(&gui_state.build_result);
+            let is_building = Arc::clone(&gui_state.is_building);
+
+            {
+                let mut is_building_lock = is_building.lock().unwrap();
+                *is_building_lock = true;
+            }
+
+            std::thread::spawn(move || {
+                let result = ProjectManager::build_project(&project_path);
+
+                {
+                    let mut result_lock = build_result.lock().unwrap();
+                    *result_lock = Some(result);
+                }
+                {
+                    let mut is_building_lock = is_building.lock().unwrap();
+                    *is_building_lock = false;
+                }
+            });
+
+            gui_state.show_build_project_popup = true;
+        });
+
+    }
+
+    pub fn show_active_popup(&mut self, ctx: &egui::Context, gui_state: &mut GuiState) {
+        if gui_state.show_build_project_popup {
+            self.render_build_project_popup(ctx, gui_state);
+        }
+    }
+
+    fn render_build_project_popup(&self, ctx: &egui::Context, gui_state: &mut GuiState) {
+        let is_building = *gui_state.is_building.lock().unwrap();
+        let result = gui_state.build_result.lock().unwrap().clone();
+
+        if is_building || result.is_some() {
+            // Block interactions with a transparent layer
+            egui::Area::new(egui::Id::new("blocking_Layer"))
+                .order(egui::Order::Foreground)
+                .interactable(false)
+                .show(ctx, |ui| {
+                    let screen_rect = ctx.screen_rect();
+                    ui.painter()
+                        .rect_filled(screen_rect, 0.0, egui::Color32::from_black_alpha(128));
+                    ui.allocate_rect(screen_rect, egui::Sense::hover());
+                });
+
+            egui::Window::new("Build Project")
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .order(egui::Order::Foreground)
+                .show(ctx, |ui| {
+                    if is_building {
+                        ui.vertical_centered(|ui| {
+                            ui.label("Building... Please wait.");
+                            ui.add(egui::Spinner::new());
+                        });
+                    } else if let Some(result) = result {
+                        ui.vertical_centered(|ui| {
+                            match &result {
+                                Ok(_) => {
+                                    ui.label("Build succeeded!");
+                                }
+                                Err(err) => {
+                                    ui.label(format!("Build failed: {}", err));
+                                }
+                            }
+                            if ui.button("OK").clicked() {
+                                match result {
+                                    Ok(_) => LOGGER.info("Build succeeded!"),
+                                    Err(err) => LOGGER.error(format!("Build failed: {}", err)),
+                                }
+                                *gui_state.build_result.lock().unwrap() = None;
+                                gui_state.show_build_project_popup = false;
+                            }
+                        });
+                    }
+                });
+
+            ctx.request_repaint();
+        }
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod game_runtime;
 pub mod gui;
 pub mod script_interpreter;
 pub mod lua_scripting;
+pub mod logger;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,93 @@
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+use chrono::Local;
+
+const MAX_CONSOLE_MESSAGES: usize = 1000;
+const MAX_STORED_MESSAGES: usize = 50000;
+
+#[derive(Clone, Debug)]
+pub struct ConsoleMessage {
+    pub text: String,
+    pub timestamp: chrono::DateTime<chrono::Local>,
+    pub message_type: ConsoleMessageType,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ConsoleMessageType {
+    Info,    // 0
+    Warning, // 1
+    Error,   // 2
+    Debug,
+}
+
+impl ConsoleMessage {
+    pub fn new(text: String, message_type: ConsoleMessageType) -> Self {
+        Self {
+            text,
+            timestamp: Local::now(),
+            message_type,
+        }
+    }
+}
+
+pub struct Logger {
+    console_messages: Mutex<Vec<ConsoleMessage>>,
+    stored_messages: Mutex<Vec<ConsoleMessage>>,
+}
+
+impl Logger {
+    fn new() -> Self {
+        Self {
+            console_messages: Mutex::new(Vec::new()),
+            stored_messages: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn log_message(&self, message: String, message_type: ConsoleMessageType) {
+        let new_message = ConsoleMessage::new(message, message_type);
+
+        {
+            let mut console_logger = self.console_messages.lock().unwrap();
+            console_logger.push(new_message.clone());
+            if console_logger.len() > MAX_CONSOLE_MESSAGES {
+                let excess = console_logger.len() - MAX_CONSOLE_MESSAGES;
+                console_logger.drain(0..excess);
+            }
+        }
+
+        {
+            let mut stored_logger = self.stored_messages.lock().unwrap();
+            stored_logger.push(new_message);
+            if stored_logger.len() > MAX_STORED_MESSAGES {
+                let excess = stored_logger.len() - MAX_STORED_MESSAGES;
+                stored_logger.drain(0..excess);
+            }
+        }
+    }
+
+    pub fn info(&self, message: impl Into<String>) {
+        self.log_message(message.into(), ConsoleMessageType::Info);
+    }
+
+    pub fn warning(&self, message: impl Into<String>) {
+        self.log_message(message.into(), ConsoleMessageType::Warning);
+    }
+
+    pub fn error(&self, message: impl Into<String>) {
+        self.log_message(message.into(), ConsoleMessageType::Error);
+    }
+
+    pub fn debug(&self, message: impl Into<String>) {
+        self.log_message(message.into(), ConsoleMessageType::Debug);
+    }
+
+    pub fn get_console_messages(&self) -> Vec<ConsoleMessage> {
+        self.console_messages.lock().unwrap().clone()
+    }
+
+    pub fn get_stored_messages(&self) -> Vec<ConsoleMessage> {
+        self.stored_messages.lock().unwrap().clone()
+    }
+}
+
+pub static LOGGER: Lazy<Logger> = Lazy::new(Logger::new);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod physics_engine;
 mod render_engine;
 mod game_runtime;
 mod lua_scripting;
+mod logger;
 
 fn main() -> Result<(), eframe::Error> {
     let options = eframe::NativeOptions {


### PR DESCRIPTION
- Refactor and improve logger
  - Simplified logging for easier integration across components.
- Enhance build project functionality
  - Added a popup window to indicate build progress, blocking other actions during the build.
  - Logs messages to the Debug panel during the build, also display colored messages in the terminal for better debugging.